### PR TITLE
fix: Remove npm cache from C1 workflow

### DIFF
--- a/.github/workflows/C1.yml
+++ b/.github/workflows/C1.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 'lts/*'
-          cache: 'npm'
+          node-version: '22'
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow error:

**Error:** `Dependencies lock file is not found`

**Root Cause:** The C1 workflow was configured with `cache: 'npm'` but the repository doesn't have a lock file (package-lock.json, npm-shrinkwrap.json, or yarn.lock).

**Fix:**
- Removed `cache: 'npm'` from the setup-node step
- Updated `node-version` from `lts/*` to `22` to avoid Node.js 20 deprecation warnings

This ensures the workflow runs correctly without requiring a lock file.