### PR TITLE
fix: Remove npm cache from C2 workflow

### DIFF
--- a/.github/workflows/C2.yml
+++ b/.github/workflows/C2.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 'lts/*'
-          cache: 'npm'
+          node-version: '22'
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow error:

**Error:** `Dependencies lock file is not found`

**Root Cause:** The C2 workflow was configured with `cache: 'npm'` but the repository doesn't have a lock file.

**Fix:**
- Removed `cache: 'npm'` from the setup-node step
- Updated `node-version` from `lts/*` to `22` to avoid Node.js 20 deprecation warnings